### PR TITLE
Migrate the door envs to the new MuJoCo bindings & a couple minor changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,9 @@ Ensure that your task and pull request:
 * [ ] Can be performed by a real robot arm 
 * [ ] Is dissimilar from current tasks
 * [ ] Contains meaningful internal variation (e.g. different object positions, etc.)
-* [ ] Conforms to the action space, observation space, and reward functions conventions used by metaworld environments
+* [ ] Conforms to the action space, observation space, and reward functions conventions used by Meta-World environments
 * [ ] Uses existing assets if they exist, and that any new assets added are high-quality
-* [ ] Follows the code qualtiy, style, testing, and documentation guidelines outlined below
+* [ ] Follows the code quality, style, testing, and documentation guidelines outlined below
 * [ ] Provides learning curves which show the task can by solved by PPO and SAC, using the implementations linked below
 
 PPO: https://github.com/rlworkgroup/garage/blob/master/src/garage/tf/algos/ppo.py
@@ -143,7 +143,7 @@ These are Meta-World specific rules which are not part of the aforementioned sty
 
 * When using external dependencies, use the `import` statement only to import whole modules, not individual classes or functions.
 
-    This applies to both packages from the standard library and 3rd-party dependencies. If a package has a long or cumbersome full path, or is used very frequently (e.g. `numpy`, `tensorflow`), you may use the keyword `as` to create a file-specific name which makes sense. Additionally, you should always follow the community concensus short names for common dependencies (see below).
+    This applies to both packages from the standard library and 3rd-party dependencies. If a package has a long or cumbersome full path, or is used very frequently (e.g. `numpy`, `tensorflow`), you may use the keyword `as` to create a file-specific name which makes sense. Additionally, you should always follow the community consensus short names for common dependencies (see below).
 
     *Do*
     ```python
@@ -154,7 +154,7 @@ These are Meta-World specific rules which are not part of the aforementioned sty
     from garage.tf.models import MLPModel
 
     q = collections.deque(10)
-    d = gym.spaces.Discrete(5)
+    d = gymnasium.spaces.Discrete(5)
     m = MLPModel(output_dim=2)
     ```
 
@@ -162,7 +162,7 @@ These are Meta-World specific rules which are not part of the aforementioned sty
     ```python
     from collections import deque
 
-    from gym.spaces import Discrete
+    from gymnasium.spaces import Discrete
     import tensorflow as tf
 
     from garage.tf.models import MLPModel
@@ -235,14 +235,14 @@ Do's and Don'ts for avoiding accidental merge commits and other headaches:
 * *Don't* use `git merge`
 * *Don't* use `git pull` (unless git tells you that your branch can be fast-forwarded)
 * *Don't* make commits in the `master` branch---always use a feature branch
-* *Do* fetch upstream (`rlworkgroup/metaworld`) frequently and keep your `master` branch up-to-date with upstream
+* *Do* fetch upstream (`Farama-Foundation/Metaworld`) frequently and keep your `master` branch up-to-date with upstream
 * *Do* rebase your feature branch on `master` frequently
 * *Do* keep only one or a few commits in your feature branch, and use `git commit --amend` to update your changes. This helps prevent long chains of identical merges during a rebase.
 
 Please see [this guide](https://gist.github.com/markreid/12e7c2203916b93d23c27a263f6091a0) for a tutorial on the workflow. Note: unlike the guide, we don't use separate `develop`/`master` branches, so all PRs should be based on `master` rather than `develop`
 
 ### Commit message format
-metaworld follows the git commit message guidelines documented [here](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53) and [here](https://chris.beams.io/posts/git-commit/). You can also find an in-depth guide to writing great commit messages [here](https://github.com/RomuloOliveira/commit-messages-guide/blob/master/README.md)
+Meta-World follows the git commit message guidelines documented [here](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53) and [here](https://chris.beams.io/posts/git-commit/). You can also find an in-depth guide to writing great commit messages [here](https://github.com/RomuloOliveira/commit-messages-guide/blob/master/README.md)
 
 In short:
 * All commit messages have an informative subject line of 50 characters
@@ -253,20 +253,20 @@ In short:
 
 These recipes assume you are working out of a private GitHub fork.
 
-If you are working directly as a contributor to `rlworkgroup`, you can replace references to `rlworkgroup` with `origin`. You also, of course, do not need to add `rlworkgroup` as a remote, since it will be `origin` in your repository.
+If you are working directly as a contributor to `Farama-Foundation`, you can replace references to `Farama-Foundation` with `origin`. You also, of course, do not need to add `Farama-Foundation` as a remote, since it will be `origin` in your repository.
 
-#### Clone your GitHub fork and setup the rlworkgroup remote
+#### Clone your GitHub fork and setup the Farama-Foundation remote
 ```sh
 git clone git@github.com:<your_github_username>/metaworld.git
 cd metaworld
-git remote add rlworkgroup git@github.com:rlworkgroup/metaworld.git
-git fetch rlworkgroup
+git remote add Farama-Foundation git@github.com:Farama-Foundation/metaworld.git
+git fetch Farama-Foundation
 ```
 
 #### Update your GitHub fork with the latest from upstream
 ```sh
-git fetch rlworkgroup
-git reset --hard master rlworkgroup/master
+git fetch Farama-Foundation
+git reset --hard master Farama-Foundation/master
 git push -f origin master
 ```
 
@@ -283,8 +283,8 @@ git push origin myfeaturebranch
 #### Rebase a feature branch so it's up-to-date with upstream and push it to your fork
 ```sh
 git checkout master
-git fetch rlworkgroup
-git reset --hard rlworkgroup/master
+git fetch Farama-Foundation
+git reset --hard Farama-Foundation/master
 git checkout myfeaturebranch
 git rebase master
 # you may need to manually reconcile merge conflicts here. Follow git's instructions.
@@ -294,4 +294,4 @@ git push -f origin myfeaturebranch # -f is frequently necessary because rebases 
 ## Release
 
 ### Modify CHANGELOG.md
-For each release in metaworld, modify [CHANGELOG.md](https://github.com/rlworkgroup/metaworld/blob/master/CHANGELOG.md) with the most relevant changes from the latest release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), which adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+For each release in metaworld, modify [CHANGELOG.md](https://github.com/Farama-Foundation/Metaworld/blob/master/CHANGELOG.md) with the most relevant changes from the latest release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), which adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Meta-World
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/rlworkgroup/metaworld/blob/master/LICENSE)
-![Build Status](https://github.com/rlworkgroup/metaworld/workflows/MetaWorld%20CI/badge.svg)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Farama-Foundation/metaworld/blob/master/LICENSE)
+![Build Status](https://github.com/Farama-Foundation/Metaworld/workflows/MetaWorld%20CI/badge.svg)
 
 __Meta-World is an open-source simulated benchmark for meta-reinforcement learning and multi-task learning consisting of 50 distinct robotic manipulation tasks.__ We aim to provide task distributions that are sufficiently broad to evaluate meta-RL algorithms' generalization ability to new behaviors.
 
@@ -20,19 +20,19 @@ __Table of Contents__
 - [Acknowledgements](#acknowledgements)
 
 ## Join the Community
-Metaworld is now maintained by the Farama Foundation! You can interact with our community and the new developers in our [discoed server](https://discord.gg/PfR7a79FpQ) 
+Meta-World is now maintained by the Farama Foundation! You can interact with our community and the new developers in our [Discord server](https://discord.gg/PfR7a79FpQ) 
 ## Installation
-Meta-World is based on MuJoCo, which has a proprietary dependency we can't set up for you. Please follow the [instructions](https://github.com/openai/mujoco-py#install-mujoco) in the mujoco-py package for help. Once you're ready to install everything, run:
+To install everything, run:
 
-```
-pip install git+https://github.com/rlworkgroup/metaworld.git@master#egg=metaworld
+```sh
+pip install git+https://github.com/Farama-Foundation/Metaworld.git@master#egg=metaworld
 ```
 
 Alternatively, you can clone the repository and install an editable version locally:
 
-```
-git clone https://github.com/rlworkgroup/metaworld.git
-cd metaworld
+```sh
+git clone https://github.com/Farama-Foundation/Metaworld.git
+cd Metaworld
 pip install -e .
 ```
 
@@ -41,11 +41,11 @@ Here is a list of benchmark environments for meta-RL (ML*) and multi-task-RL (MT
 * [__ML1__](https://meta-world.github.io/figures/ml1.gif) is a meta-RL benchmark environment which tests few-shot adaptation to goal variation within single task. You can choose to test variation within any of [50 tasks](https://meta-world.github.io/figures/ml45-1080p.gif) for this benchmark.
 * [__ML10__](https://meta-world.github.io/figures/ml10.gif) is a meta-RL benchmark which tests few-shot adaptation to new tasks. It comprises 10 meta-train tasks, and 3 test tasks.
 * [__ML45__](https://meta-world.github.io/figures/ml45-1080p.gif) is a meta-RL benchmark which tests few-shot adaptation to new tasks. It comprises 45 meta-train tasks and 5 test tasks.
-* [__MT10__](https://meta-world.github.io/figures/mt10.gif), __MT1__, and __MT50__ are multi-task-RL benchmark environments for learning a multi-task policy that perform 10, 1, and 50 training tasks respectively. __MT1__ is similar to __ML1__ becau you can choose to test variation within any of [50 tasks](https://meta-world.github.io/figures/ml45-1080p.gif) for this benchmark.  In the original Metaworld experiments, we augment MT10 and MT50 environment observations with a one-hot vector which identifies the task. We don't enforce how users utilize task one-hot vectors, however one solution would be to use a Gym wrapper such as [this one](https://github.com/rlworkgroup/garage/blob/master/src/garage/envs/multi_env_wrapper.py)
+* [__MT10__](https://meta-world.github.io/figures/mt10.gif), __MT1__, and __MT50__ are multi-task-RL benchmark environments for learning a multi-task policy that perform 10, 1, and 50 training tasks respectively. __MT1__ is similar to __ML1__ because you can choose to test variation within any of [50 tasks](https://meta-world.github.io/figures/ml45-1080p.gif) for this benchmark.  In the original Meta-World experiments, we augment MT10 and MT50 environment observations with a one-hot vector which identifies the task. We don't enforce how users utilize task one-hot vectors, however one solution would be to use a Gym wrapper such as [this one](https://github.com/rlworkgroup/garage/blob/master/src/garage/envs/multi_env_wrapper.py)
 
 
 ### Basics
-We provide a `Benchmark` API, that allows constructing environments following the [`gym.Env`](https://github.com/openai/gym/blob/c33cfd8b2cc8cac6c346bc2182cd568ef33b8821/gym/core.py#L8) interface.
+We provide a `Benchmark` API, that allows constructing environments following the [`gymnasium.Env`](https://github.com/Farama-Foundation/Gymnasium/blob/main/gymnasium/core.py#L21) interface.
 
 To use a `Benchmark`, first construct it (this samples the tasks allowed for one run of an algorithm on the benchmark).
 Then, construct at least one instance of each environment listed in `benchmark.train_classes` and `benchmark.test_classes`.
@@ -86,7 +86,7 @@ env.set_task(task)  # Set task
 
 obs = env.reset()  # Reset environment
 a = env.action_space.sample()  # Sample an action
-obs, reward, done, info = env.step(a)  # Step the environoment with the sampled random action
+obs, reward, done, info = env.step(a)  # Step the environment with the sampled random action
 ```
 __MT1__ can be run the same way except that it does not contain any `test_tasks`
 ### Running a benchmark
@@ -108,7 +108,7 @@ for name, env_cls in ml10.train_classes.items():
 for env in training_envs:
   obs = env.reset()  # Reset environment
   a = env.action_space.sample()  # Sample an action
-  obs, reward, done, info = env.step(a)  # Step the environoment with the sampled random action
+  obs, reward, done, info = env.step(a)  # Step the environment with the sampled random action
 ```
 Create an environment with test tasks (this only works for ML10 and ML45, since MT10 and MT50 don't have a separate set of test tasks):
 ```python
@@ -128,11 +128,11 @@ for name, env_cls in ml10.test_classes.items():
 for env in testing_envs:
   obs = env.reset()  # Reset environment
   a = env.action_space.sample()  # Sample an action
-  obs, reward, done, info = env.step(a)  # Step the environoment with the sampled random action
+  obs, reward, done, info = env.step(a)  # Step the environment with the sampled random action
 ```
 
 ## Accessing Single Goal Environments
-You may wish to only access individual environments used in the Metaworld benchmark for your research.
+You may wish to only access individual environments used in the Meta-World benchmark for your research.
 We provide constructors for creating environments where the goal has been hidden (by zeroing out the goal in
 the observation) and environments where the goal is observable. They are called GoalHidden and GoalObservable
 environments respectively.
@@ -152,7 +152,7 @@ door_open_goal_hidden_cls = ALL_V2_ENVIRONMENTS_GOAL_HIDDEN["door-open-v2-goal-h
 env = door_open_goal_hidden_cls()
 env.reset()  # Reset environment
 a = env.action_space.sample()  # Sample an action
-obs, reward, done, info = env.step(a)  # Step the environoment with the sampled random action
+obs, reward, done, info = env.step(a)  # Step the environment with the sampled random action
 assert (obs[-3:] == np.zeros(3)).all() # goal will be zeroed out because env is HiddenGoal
 
 # You can choose to initialize the random seed of the environment.
@@ -164,7 +164,7 @@ env1.reset()  # Reset environment
 env2.reset()
 a1 = env1.action_space.sample()  # Sample an action
 a2 = env2.action_space.sample()
-next_obs1, _, _, _ = env1.step(a1)  # Step the environoment with the sampled random action
+next_obs1, _, _, _ = env1.step(a1)  # Step the environment with the sampled random action
 next_obs2, _, _, _ = env2.step(a2)  
 assert (next_obs1[-3:] == next_obs2[-3:]).all() # 2 envs initialized with the same seed will have the same goal
 assert not (next_obs2[-3:] == np.zeros(3)).all()   # The env's are goal observable, meaning the goal is not zero'd out
@@ -174,7 +174,7 @@ env1.reset()  # Reset environment
 env3.reset()
 a1 = env1.action_space.sample()  # Sample an action
 a3 = env3.action_space.sample()
-next_obs1, _, _, _ = env1.step(a1)  # Step the environoment with the sampled random action
+next_obs1, _, _, _ = env1.step(a1)  # Step the environment with the sampled random action
 next_obs3, _, _, _ = env3.step(a3)  
 
 assert not (next_obs1[-3:] == next_obs3[-3:]).all() # 2 envs initialized with different seeds will have different goals
@@ -199,11 +199,11 @@ If you use Meta-World for academic research, please kindly cite our CoRL 2019 pa
 ```
 
 ## Accompanying Baselines
-If you're looking for implementations of the baselines algorithms used in the Metaworld conference publication, please look at our sister directory, [Garage](https://github.com/rlworkgroup/garage). 
+If you're looking for implementations of the baselines algorithms used in the Meta-World conference publication, please look at our sister directory, [Garage](https://github.com/rlworkgroup/garage). 
 Note that these aren't the exact same baselines that were used in the original conference publication, however they are true to the original baselines.
 
 ## Become a Contributor
-We welcome all contributions to Meta-World. Please refer to the [contributor's guide](https://github.com/rlworkgroup/metaworld/blob/master/CONTRIBUTING.md) for how to prepare your contributions.
+We welcome all contributions to Meta-World. Please refer to the [contributor's guide](https://github.com/Farama-Foundation/Metaworld/blob/master/CONTRIBUTING.md) for how to prepare your contributions.
 
 ## Acknowledgements
 Meta-World is a work by [Tianhe Yu (Stanford University)](https://cs.stanford.edu/~tianheyu/), [Deirdre Quillen (UC Berkeley)](https://scholar.google.com/citations?user=eDQsOFMAAAAJ&hl=en), [Zhanpeng He (Columbia University)](https://zhanpenghe.github.io), [Ryan Julian (University of Southern California)](https://ryanjulian.me), [Karol Hausman (Google AI)](https://karolhausman.github.io),  [Chelsea Finn (Stanford University)](https://ai.stanford.edu/~cbfinn/) and [Sergey Levine (UC Berkeley)](https://people.eecs.berkeley.edu/~svlevine/).

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_door_unlock_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_door_unlock_v2.py
@@ -8,7 +8,6 @@ from metaworld.envs.mujoco.sawyer_xyz.sawyer_xyz_env import SawyerXYZEnv, _asser
 
 class SawyerDoorUnlockEnvV2(SawyerXYZEnv):
     def __init__(self):
-
         hand_low = (-0.5, 0.40, -0.15)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.1, 0.8, 0.15)
@@ -23,12 +22,12 @@ class SawyerDoorUnlockEnvV2(SawyerXYZEnv):
         )
 
         self.init_config = {
-            'obj_init_pos': np.array([0, 0.85, 0.15]),
-            'hand_init_pos': np.array([0, 0.6, 0.2], dtype=np.float32),
+            "obj_init_pos": np.array([0, 0.85, 0.15]),
+            "hand_init_pos": np.array([0, 0.6, 0.2], dtype=np.float32),
         }
         self.goal = np.array([0, 0.85, 0.1])
-        self.obj_init_pos = self.init_config['obj_init_pos']
-        self.hand_init_pos = self.init_config['hand_init_pos']
+        self.obj_init_pos = self.init_config["obj_init_pos"]
+        self.hand_init_pos = self.init_config["hand_init_pos"]
 
         self._lock_length = 0.1
 
@@ -40,7 +39,7 @@ class SawyerDoorUnlockEnvV2(SawyerXYZEnv):
 
     @property
     def model_name(self):
-        return full_v2_path_for('sawyer_xyz/sawyer_door_lock.xml')
+        return full_v2_path_for("sawyer_xyz/sawyer_door_lock.xml")
 
     @_assert_task_is_set
     def evaluate_state(self, obs, action):
@@ -50,17 +49,17 @@ class SawyerDoorUnlockEnvV2(SawyerXYZEnv):
             tcp_open,
             obj_to_target,
             near_button,
-            button_pressed
+            button_pressed,
         ) = self.compute_reward(action, obs)
 
         info = {
-            'success': float(obj_to_target <= 0.02),
-            'near_object': float(tcp_to_obj <= 0.05),
-            'grasp_success': float(tcp_open > 0),
-            'grasp_reward': near_button,
-            'in_place_reward': button_pressed,
-            'obj_to_target': obj_to_target,
-            'unscaled_reward': reward,
+            "success": float(obj_to_target <= 0.02),
+            "near_object": float(tcp_to_obj <= 0.05),
+            "grasp_success": float(tcp_open > 0),
+            "grasp_reward": near_button,
+            "in_place_reward": button_pressed,
+            "obj_to_target": obj_to_target,
+            "unscaled_reward": reward,
         }
 
         return reward, info
@@ -68,18 +67,18 @@ class SawyerDoorUnlockEnvV2(SawyerXYZEnv):
     @property
     def _target_site_config(self):
         return [
-            ('goal_unlock', self._target_pos),
-            ('goal_lock', np.array([10., 10., 10.]))
+            ("goal_unlock", self._target_pos),
+            ("goal_lock", np.array([10.0, 10.0, 10.0])),
         ]
 
     def _get_id_main_object(self):
         return None
 
     def _get_pos_objects(self):
-        return self._get_site_pos('lockStartUnlock')
+        return self._get_site_pos("lockStartUnlock")
 
     def _get_quat_objects(self):
-        return self.sim.data.get_body_xquat('door_link')
+        return self.data.body("door_link").xquat
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()
@@ -90,13 +89,12 @@ class SawyerDoorUnlockEnvV2(SawyerXYZEnv):
 
     def reset_model(self):
         self._reset_hand()
-        door_pos = self._get_state_rand_vec()
 
-        self.sim.model.body_pos[self.model.body_name2id('door')] = door_pos
+        self.model.body("door").pos = self._get_state_rand_vec()
         self._set_obj_xyz(1.5708)
 
-        self.obj_init_pos = self.get_body_com('lock_link')
-        self._target_pos = self.obj_init_pos + np.array([.1, -.04, .0])
+        self.obj_init_pos = self.data.body("lock_link").xpos
+        self._target_pos = self.obj_init_pos + np.array([0.1, -0.04, 0.0])
 
         return self._get_obs()
 
@@ -106,13 +104,11 @@ class SawyerDoorUnlockEnvV2(SawyerXYZEnv):
         lock = obs[4:7]
 
         # Add offset to track gripper's shoulder, rather than fingers
-        offset = np.array([.0, .055, .07])
+        offset = np.array([0.0, 0.055, 0.07])
 
-        scale = np.array([0.25, 1., 0.5])
+        scale = np.array([0.25, 1.0, 0.5])
         shoulder_to_lock = (gripper + offset - lock) * scale
-        shoulder_to_lock_init = (
-            self.init_tcp + offset - self.obj_init_pos
-        ) * scale
+        shoulder_to_lock_init = (self.init_tcp + offset - self.obj_init_pos) * scale
 
         # This `ready_to_push` reward should be a *hint* for the agent, not an
         # end in itself. Make sure to devalue it compared to the value of
@@ -121,7 +117,7 @@ class SawyerDoorUnlockEnvV2(SawyerXYZEnv):
             np.linalg.norm(shoulder_to_lock),
             bounds=(0, 0.02),
             margin=np.linalg.norm(shoulder_to_lock_init),
-            sigmoid='long_tail',
+            sigmoid="long_tail",
         )
 
         obj_to_target = abs(self._target_pos[0] - lock[0])
@@ -129,7 +125,7 @@ class SawyerDoorUnlockEnvV2(SawyerXYZEnv):
             obj_to_target,
             bounds=(0, 0.005),
             margin=self._lock_length,
-            sigmoid='long_tail',
+            sigmoid="long_tail",
         )
 
         reward = 2 * ready_to_push + 8 * pushed
@@ -140,5 +136,5 @@ class SawyerDoorUnlockEnvV2(SawyerXYZEnv):
             obs[3],
             obj_to_target,
             ready_to_push,
-            pushed
+            pushed,
         )

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_door_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_door_v2.py
@@ -9,13 +9,12 @@ from metaworld.envs.mujoco.sawyer_xyz.sawyer_xyz_env import SawyerXYZEnv, _asser
 
 class SawyerDoorEnvV2(SawyerXYZEnv):
     def __init__(self):
-
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
-        obj_low = (0., 0.85, 0.15)
+        obj_low = (0.0, 0.85, 0.15)
         obj_high = (0.1, 0.95, 0.15)
-        goal_low = (-.3, 0.4, 0.1499)
-        goal_high = (-.2, 0.5, 0.1501)
+        goal_low = (-0.3, 0.4, 0.1499)
+        goal_high = (-0.2, 0.5, 0.1501)
 
         super().__init__(
             self.model_name,
@@ -24,18 +23,18 @@ class SawyerDoorEnvV2(SawyerXYZEnv):
         )
 
         self.init_config = {
-            'obj_init_angle': np.array([0.3, ]),
-            'obj_init_pos': np.array([0.1, 0.95, 0.15]),
-            'hand_init_pos': np.array([0, 0.6, 0.2]),
+            "obj_init_angle": np.array([0.3]),
+            "obj_init_pos": np.array([0.1, 0.95, 0.15]),
+            "hand_init_pos": np.array([0, 0.6, 0.2]),
         }
 
         self.goal = np.array([-0.2, 0.7, 0.15])
-        self.obj_init_pos = self.init_config['obj_init_pos']
-        self.obj_init_angle = self.init_config['obj_init_angle']
-        self.hand_init_pos = self.init_config['hand_init_pos']
+        self.obj_init_pos = self.init_config["obj_init_pos"]
+        self.obj_init_angle = self.init_config["obj_init_angle"]
+        self.hand_init_pos = self.init_config["hand_init_pos"]
 
-        self.door_angle_idx = self.model.get_joint_qpos_addr('doorjoint')
-        
+        self.door_qpos_adr = self.model.joint("doorjoint").qposadr.item()
+        self.door_qvel_adr = self.model.joint("doorjoint").dofadr.item()
 
         self._random_reset_space = Box(
             np.array(obj_low),
@@ -45,7 +44,7 @@ class SawyerDoorEnvV2(SawyerXYZEnv):
 
     @property
     def model_name(self):
-        return full_v2_path_for('sawyer_xyz/sawyer_door_pull.xml')
+        return full_v2_path_for("sawyer_xyz/sawyer_door_pull.xml")
 
     @_assert_task_is_set
     def evaluate_state(self, obs, action):
@@ -59,13 +58,13 @@ class SawyerDoorEnvV2(SawyerXYZEnv):
         success = float(abs(obs[4] - self._target_pos[0]) <= 0.08)
 
         info = {
-            'success': success,
-            'near_object': reward_ready,
-            'grasp_success': reward_grab >= 0.5,
-            'grasp_reward': reward_grab,
-            'in_place_reward': reward_success,
-            'obj_to_target': 0,
-            'unscaled_reward': reward,
+            "success": success,
+            "near_object": reward_ready,
+            "grasp_success": reward_grab >= 0.5,
+            "grasp_reward": reward_grab,
+            "in_place_reward": reward_success,
+            "obj_to_target": 0,
+            "unscaled_reward": reward,
         }
 
         return reward, info
@@ -75,31 +74,31 @@ class SawyerDoorEnvV2(SawyerXYZEnv):
         return []
 
     def _get_pos_objects(self):
-        return self.data.get_geom_xpos('handle').copy()
+        return self.data.geom("handle").xpos.copy()
 
     def _get_quat_objects(self):
-        return Rotation.from_matrix(self.data.get_geom_xmat('handle')).as_quat()
+        return Rotation.from_matrix(self.data.geom("handle").xmat.reshape(3, 3)).as_quat()
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.copy()
         qvel = self.data.qvel.copy()
-        qpos[self.door_angle_idx] = pos
-        qvel[self.door_angle_idx] = 0
+        qpos[self.door_qpos_adr] = pos
+        qvel[self.door_qvel_adr] = 0
         self.set_state(qpos.flatten(), qvel.flatten())
 
     def reset_model(self):
         self._reset_hand()
 
-        self.objHeight = self.data.get_geom_xpos('handle')[2]
+        self.objHeight = self.data.geom("handle").xpos[2]
 
         self.obj_init_pos = self._get_state_rand_vec()
-        self._target_pos = self.obj_init_pos + np.array([-0.3, -0.45, 0.])
+        self._target_pos = self.obj_init_pos + np.array([-0.3, -0.45, 0.0])
 
-        self.sim.model.body_pos[self.model.body_name2id('door')] = self.obj_init_pos
-        self.sim.model.site_pos[self.model.site_name2id('goal')] = self._target_pos
+        self.model.body("door").pos = self.obj_init_pos
+        self.model.site("goal").pos = self._target_pos
         self._set_obj_xyz(0)
-        self.maxPullDist = np.linalg.norm(self.data.get_geom_xpos('handle')[:-1] - self._target_pos[:-1])
-        self.target_reward = 1000*self.maxPullDist + 1000*2
+        self.maxPullDist = np.linalg.norm(self.data.geom("handle").xpos[:-1] - self._target_pos[:-1])
+        self.target_reward = 1000 * self.maxPullDist + 1000 * 2
 
         return self._get_obs()
 
@@ -121,18 +120,22 @@ class SawyerDoorEnvV2(SawyerXYZEnv):
             floor = 0.04 * np.log(radius - threshold) + 0.4
         # prevent the hand from running into the handle prematurely by keeping
         # it above the "floor"
-        above_floor = 1.0 if hand[2] >= floor else reward_utils.tolerance(
-            floor - hand[2],
-            bounds=(0.0, 0.01),
-            margin=floor / 2.0,
-            sigmoid='long_tail',
+        above_floor = (
+            1.0
+            if hand[2] >= floor
+            else reward_utils.tolerance(
+                floor - hand[2],
+                bounds=(0.0, 0.01),
+                margin=floor / 2.0,
+                sigmoid="long_tail",
+            )
         )
         # move the hand to a position between the handle and the main door body
         in_place = reward_utils.tolerance(
             np.linalg.norm(hand - door - np.array([0.05, 0.03, -0.01])),
             bounds=(0, threshold / 2.0),
             margin=0.5,
-            sigmoid='long_tail',
+            sigmoid="long_tail",
         )
         ready_to_open = reward_utils.hamacher_product(above_floor, in_place)
 
@@ -140,25 +143,27 @@ class SawyerDoorEnvV2(SawyerXYZEnv):
         door_angle = -theta
         a = 0.2  # Relative importance of just *trying* to open the door at all
         b = 0.8  # Relative importance of fully opening the door
-        opened = a * float(theta < -np.pi/90.) + b * reward_utils.tolerance(
-            np.pi/2. + np.pi/6 - door_angle,
+        opened = a * float(theta < -np.pi / 90.0) + b * reward_utils.tolerance(
+            np.pi / 2.0 + np.pi / 6 - door_angle,
             bounds=(0, 0.5),
-            margin=np.pi/3.,
-            sigmoid='long_tail',
+            margin=np.pi / 3.0,
+            sigmoid="long_tail",
         )
 
         return ready_to_open, opened
 
     def compute_reward(self, actions, obs):
-        theta = self.data.get_joint_qpos('doorjoint')
+        theta = self.data.joint("doorjoint").qpos
 
         reward_grab = SawyerDoorEnvV2._reward_grab_effort(actions)
         reward_steps = SawyerDoorEnvV2._reward_pos(obs, theta)
 
-        reward = sum((
-            2.0 * reward_utils.hamacher_product(reward_steps[0], reward_grab),
-            8.0 * reward_steps[1],
-        ))
+        reward = sum(
+            (
+                2.0 * reward_utils.hamacher_product(reward_steps[0], reward_grab),
+                8.0 * reward_steps[1],
+            )
+        )
 
         # Override reward on success flag
         if abs(obs[4] - self._target_pos[0]) <= 0.08:

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ required = [
     'gymnasium>=0.15.4',
     'mujoco',
     'numpy>=1.18',
+    'scipy',
 ]
 
 


### PR DESCRIPTION
- Migrated `door-open-v2`, `door-close-v2`, `door-lock-v2`, `door-unlock-v2` to the new MuJoCo Python bindings. Validated that the env-specific values match (to a close degree) with values observed in the master branch of [Farama-Foundation/Metaworld](https://github.com/Farama-Foundation/Metaworld).
- Fixed some typos and inconsistencies in the README / CONTRIBUTING docs.
- Added a missing, yet needed, dependency to `setup.py`.

Note that the `sawyer_door_*.py` files also have some changes that alter the code formatting & style. That's because I used the `black` formatter for consistency with changes proposed by #1.